### PR TITLE
eiger detector name regex

### DIFF
--- a/streamvis/receiver.py
+++ b/streamvis/receiver.py
@@ -1,4 +1,5 @@
 import logging
+import re
 from collections import deque
 from datetime import datetime
 
@@ -100,7 +101,7 @@ class StreamAdapter:
         """
         # Eiger workaround
         detector_name = metadata.get("detector_name")
-        if detector_name and detector_name.startswith("Eiger"):
+        if detector_name and re.match("(^[A-Za-z]*).EG([0-9A-Za-z]*)",detector_name):
             return np.copy(np.flipud(image))
 
         # parse metadata


### PR DESCRIPTION
This PR improves the detection of an Eiger incoming stream, which is necessary to flip the image. It verifies it by using a regular expression, following the standard <beamline>.EG<id>.